### PR TITLE
Add cooldown / role permissions

### DIFF
--- a/doc.json
+++ b/doc.json
@@ -2,7 +2,28 @@
   "name": "aaa-game",
   "description": "(Typed-safe) An alphabetical text game for Brickadia.",
   "author": "Snepderg, Critical Floof",
-  "config": {},
+  "config": {
+    "Limited Mode": {
+      "description": "Only users with Cooldown Bypass Role are allowed to use the command.",
+      "default": "false",
+      "type": "boolean"
+    },
+    "Command Cooldown": {
+        "description": "Cooldown time (in seconds) for using aaa-game.",
+        "default": 60,
+        "type": "number"
+    },
+    "Cooldown Bypass Role": {
+        "description": "The role which isn't affected by silly cooldowns.",
+        "default": "Admin",
+        "type": "role"
+    },
+    "Blacklist Role": {
+        "description": "The role which prevents any use of aaa-game.",
+        "default": "Admin",
+        "type": "role"
+    }
+  },
   "commands": [
     {
       "name": "/aaa",

--- a/omegga.plugin.ts
+++ b/omegga.plugin.ts
@@ -55,10 +55,6 @@ export default class Plugin implements OmeggaPlugin<any, Storage> {
     loadedGameState ? textGame.setPhrase(loadedGameState) : textGame.setPhrase("A");
 
     this.omegga.on("cmd:aaa", async (name: string, ...args: string[]) => {
-      // Enforce cooldowns and permissions
-      if (!this.isAuthorized(name)) return;
-      this.setAuthorizedTimeout(name)
-
       // Default case: If no arguments are provided, whisper the current phrase to the user
       if (args.length === 0) {
         this.omegga.whisper(name, `The current phrase is ${textGame.getPhrase()}.`);
@@ -67,6 +63,10 @@ export default class Plugin implements OmeggaPlugin<any, Storage> {
 
       // Validate the user's answer
       if (textGame.checkAnswer(args.join(" "))) {
+        // Enforce cooldowns and permissions
+        if (!this.isAuthorized(name)) return;
+        this.setAuthorizedTimeout(name)
+
         textGame.incrementPhrase();
         this.store.set("phrase", textGame.getPhrase());
         this.omegga.broadcast( `${name} got the correct answer! The current phrase is ${textGame.getPhrase()}.`);


### PR DESCRIPTION
This implements cooldown logic from Critical Floof's existing omegga plugins.

- Adds a cooldown (in seconds) which can be enabled to restrict plugin usage.
- Adds a bypass role which ignores the cooldown
- The bypass role also applies to Limited Mode, wherein only users with the role can use the plugin (besides checking the sequence)
- Server owners can blacklist a role from using the plugin.